### PR TITLE
Health host header

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -104,6 +104,8 @@ resource "google_compute_http_health_check" "default" {
   request_path       = element(split(",", element(var.backend_params, count.index)), 0)
   port               = element(split(",", element(var.backend_params, count.index)), 2)
   check_interval_sec = element(split(",", element(var.backend_params, count.index)), 4)
+  # Check if host header is in the backend_params list, add it to health check if it is.
+  host               = length(split(",", (element(var.backend_params, count.index)))) > 5 ? element(split(",", element(var.backend_params, count.index)), 5) : ""
 }
 
 resource "google_compute_https_health_check" "default" {
@@ -113,6 +115,8 @@ resource "google_compute_https_health_check" "default" {
   request_path       = element(split(",", element(var.backend_params, count.index)), 0)
   port               = element(split(",", element(var.backend_params, count.index)), 2)
   check_interval_sec = element(split(",", element(var.backend_params, count.index)), 4)
+  # Check if host header is in the backend_params list, add it to health check if it is.
+  host               = length(split(",", (element(var.backend_params, count.index)))) > 5 ? element(split(",", element(var.backend_params, count.index)), 5) : ""
 }
 
 resource "google_compute_firewall" "default-hc" {

--- a/variables.tf
+++ b/variables.tf
@@ -50,7 +50,7 @@ variable backends {
 }
 
 variable backend_params {
-  description = "Comma-separated encoded list of parameters in order: health check path, service port name, service port, backend timeout seconds"
+  description = "Comma-separated encoded list of parameters in order: health check path, service port name, service port, backend timeout seconds, host header"
   type        = list
 }
 


### PR DESCRIPTION
WHAT

Add the option for host header to be included in health checks.

WHY

we need to supply a host header for health checks to the new style proxy.  Our current setup doesn't include host headers.

TEST

following branch shows no changes.  I have manually added the host header to both the GLB and MIG
https://gitlab.urbn.com/infrastructure/ecomm-terraform/merge_requests/new/diffs?merge_request%5Bsource_branch%5D=an_health_header