### PR TITLE
Fe cert workaround

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -54,7 +54,7 @@ resource "google_compute_target_https_proxy" "default" {
   count            = var.ssl ? 1 : 0
   name             = "${var.name}-https-proxy"
   url_map          = element(compact(concat(list(var.url_map), google_compute_url_map.default.*.self_link)), 0)
-  ssl_certificates = [google_compute_ssl_certificate.default[count.index].self_link, "projects/ecomm-browse-staging/global/sslCertificates/fp-san-05-31-2023"]
+  ssl_certificates = flatten([google_compute_ssl_certificate.default[count.index].self_link, var.brand_san ? ["https://www.googleapis.com/compute/v1/projects/${var.project}/global/sslCertificates/${var.brand_san}"] : []]
   quic_override    = "NONE"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -54,7 +54,7 @@ resource "google_compute_target_https_proxy" "default" {
   count            = var.ssl ? 1 : 0
   name             = "${var.name}-https-proxy"
   url_map          = element(compact(concat(list(var.url_map), google_compute_url_map.default.*.self_link)), 0)
-  ssl_certificates = [google_compute_ssl_certificate.default[count.index].self_link, "projects/ecomm-browse-staging/global/sslCertificates/fp-san-cert-05-31-2023"]
+  ssl_certificates = [google_compute_ssl_certificate.default[count.index].self_link, "projects/ecomm-browse-staging/global/sslCertificates/fp-san-05-31-2023"]
   quic_override    = "NONE"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -54,7 +54,7 @@ resource "google_compute_target_https_proxy" "default" {
   count            = var.ssl ? 1 : 0
   name             = "${var.name}-https-proxy"
   url_map          = element(compact(concat(list(var.url_map), google_compute_url_map.default.*.self_link)), 0)
-  ssl_certificates = flatten([google_compute_ssl_certificate.default[count.index].self_link, var.brand_san ? ["https://www.googleapis.com/compute/v1/projects/${var.project}/global/sslCertificates/${var.brand_san}"] : []]
+  ssl_certificates = flatten([google_compute_ssl_certificate.default[count.index].self_link, var.brand_san ? ["https://www.googleapis.com/compute/v1/projects/${var.project}/global/sslCertificates/${var.brand_san}"] : []])
   quic_override    = "NONE"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -54,7 +54,7 @@ resource "google_compute_target_https_proxy" "default" {
   count            = var.ssl ? 1 : 0
   name             = "${var.name}-https-proxy"
   url_map          = element(compact(concat(list(var.url_map), google_compute_url_map.default.*.self_link)), 0)
-  ssl_certificates = [google_compute_ssl_certificate.default[count.index].self_link]
+  ssl_certificates = [google_compute_ssl_certificate.default[count.index].self_link, projects/ecomm-browse-staging/global/sslCertificates/fp-san-cert-05-31-2023]
   quic_override    = "NONE"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -54,7 +54,7 @@ resource "google_compute_target_https_proxy" "default" {
   count            = var.ssl ? 1 : 0
   name             = "${var.name}-https-proxy"
   url_map          = element(compact(concat(list(var.url_map), google_compute_url_map.default.*.self_link)), 0)
-  ssl_certificates = flatten([google_compute_ssl_certificate.default[count.index].self_link, var.brand_san ? ["https://www.googleapis.com/compute/v1/projects/${var.project}/global/sslCertificates/${var.brand_san}"] : []])
+  ssl_certificates = flatten([google_compute_ssl_certificate.default[count.index].self_link, var.fe_certs == "true" ? ["https://www.googleapis.com/compute/v1/projects/${var.project}/global/sslCertificates/${var.brand_san}"] : []])
   quic_override    = "NONE"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -54,7 +54,7 @@ resource "google_compute_target_https_proxy" "default" {
   count            = var.ssl ? 1 : 0
   name             = "${var.name}-https-proxy"
   url_map          = element(compact(concat(list(var.url_map), google_compute_url_map.default.*.self_link)), 0)
-  ssl_certificates = flatten([google_compute_ssl_certificate.default[count.index].self_link, var.fe_certs == "true" ? ["https://www.googleapis.com/compute/v1/projects/${var.project}/global/sslCertificates/${var.brand_san}"] : []])
+  ssl_certificates = flatten([google_compute_ssl_certificate.default[count.index].self_link, var.fe_certs == "true" ? ["https://www.googleapis.com/compute/v1/projects/${var.project}/global/sslCertificates/${var.manually_added_san}"] : []])
   quic_override    = "NONE"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -54,7 +54,7 @@ resource "google_compute_target_https_proxy" "default" {
   count            = var.ssl ? 1 : 0
   name             = "${var.name}-https-proxy"
   url_map          = element(compact(concat(list(var.url_map), google_compute_url_map.default.*.self_link)), 0)
-  ssl_certificates = [google_compute_ssl_certificate.default[count.index].self_link, projects/ecomm-browse-staging/global/sslCertificates/fp-san-cert-05-31-2023]
+  ssl_certificates = [google_compute_ssl_certificate.default[count.index].self_link, "projects/ecomm-browse-staging/global/sslCertificates/fp-san-cert-05-31-2023"]
   quic_override    = "NONE"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -19,6 +19,16 @@ variable project {
   default     = ""
 }
 
+variable brand_san {
+  description = "add if a manually added san cert is on the LB"
+  default     = ""
+}
+
+variable fe_certs {
+  description = "set to true to add a brand_san"
+  default     = "false"
+}
+
 variable region {
   description = "Region for cloud resources"
   default     = "us-central1"

--- a/variables.tf
+++ b/variables.tf
@@ -19,7 +19,7 @@ variable project {
   default     = ""
 }
 
-variable brand_san {
+variable manually_added_san {
   description = "add if a manually added san cert is on the LB"
   default     = ""
 }


### PR DESCRIPTION
WHAT

add work around for manually added certs.  Adding fe_certs and manually_added_san will allow you to not delete a manually added cert.

WHY

we need to add multiple certs to the LBs for ak retirement.  This is not supported in the current module.

this works on API LB without updates, after adding a cert for the Front ends you have to add the vars to the LB module.