### PR TITLE
http to https redirect

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -72,7 +72,7 @@ resource "google_compute_target_http_proxy" "http_redirect" {
   project = var.project
   count   = var.https_redirect ? 1 : 0
   name    = "${var.name}-http-redirect"
-  url_map = element(compact(concat(list(var.url_map), google_compute_url_map.https_redirect.*.self_link)), 0)
+  url_map = google_compute_url_map.https_redirect.*.self_link
 }
 
 resource "google_compute_global_forwarding_rule" "http_redirect" {

--- a/main.tf
+++ b/main.tf
@@ -24,14 +24,6 @@ resource "google_compute_global_address" "default" {
   name    = "${var.name}-address"
 }
 
-resource "google_compute_global_forwarding_rule" "http" {
-  project    = var.project
-  name       = var.name
-  target     = google_compute_target_http_proxy.default.self_link
-  ip_address = data.google_compute_global_address.default.address
-  port_range = "80"
-}
-
 resource "google_compute_global_forwarding_rule" "https" {
   project    = var.project
   count      = var.ssl ? 1 : 0
@@ -39,13 +31,6 @@ resource "google_compute_global_forwarding_rule" "https" {
   target     = google_compute_target_https_proxy.default[count.index].self_link
   ip_address = data.google_compute_global_address.default.address
   port_range = "443"
-}
-
-# HTTP proxy when ssl is false
-resource "google_compute_target_http_proxy" "default" {
-  project = var.project
-  name    = "${var.name}-http-proxy"
-  url_map = element(compact(concat(list(var.url_map), google_compute_url_map.default.*.self_link)), 0)
 }
 
 # HTTPS proxy  when ssl is true

--- a/main.tf
+++ b/main.tf
@@ -60,7 +60,7 @@ resource "google_compute_ssl_certificate" "default" {
 resource "google_compute_url_map" "https_redirect" {
   project = var.project
   count   = var.https_redirect ? 1 : 0
-  name    = "${var.name}-url-map-https-redirect"
+  name    = "${var.name}-https-redirect"
   default_url_redirect {
     https_redirect         = true
     redirect_response_code = "MOVED_PERMANENTLY_DEFAULT"
@@ -68,18 +68,18 @@ resource "google_compute_url_map" "https_redirect" {
   }
 }
 
-resource "google_compute_target_http_proxy" "http_redirect" {
+resource "google_compute_target_http_proxy" "https_redirect" {
   project = var.project
   count   = var.https_redirect ? 1 : 0
-  name    = "${var.name}-http-redirect"
-  url_map = google_compute_url_map.https_redirect.*.self_link
+  name    = "${var.name}-https-redirect"
+  url_map = google_compute_url_map.https_redirect[count.index].self_link
 }
 
-resource "google_compute_global_forwarding_rule" "http_redirect" {
+resource "google_compute_global_forwarding_rule" "https_redirect" {
   project    = var.project
   count      = var.https_redirect ? 1 : 0
   name       = "${var.name}-https-redirect"
-  target     = google_compute_target_http_proxy.http_redirect[count.index].self_link
+  target     = google_compute_target_http_proxy.https_redirect[count.index].self_link
   ip_address = data.google_compute_global_address.default.address
   port_range = "80"
 }


### PR DESCRIPTION
WHAT:

Remove http from the load balancer and create an http->https redirect if the variable `https_redirect` is set to `true`

WHY:

We will no longer be using Akamai to automatically do http->https redirects