### PR TITLE
Devops 12666 security policies

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -114,7 +114,7 @@ resource "google_compute_backend_service" "default" {
   protocol                        = var.ssl ? "HTTPS" : "HTTP"
   timeout_sec                     = element(split(",", element(var.backend_params, count.index)), 3)
   # not using element operator since the default behavior is to roll over (mod operation) the index which will return the wrong item from the list if index 6 does not exist
-  security_policy                 = split(",", element(var.backend_params, count.index))[6] ? split(",", element(var.backend_params, count.index))[6] : var.security_policy
+  security_policy                 = split(",", element(var.backend_params, count.index))[6] != "" ? split(",", element(var.backend_params, count.index))[6] : var.security_policy
   health_checks                   = [element(concat(google_compute_https_health_check.default.*.self_link, google_compute_http_health_check.default.*.self_link), count.index)]
   connection_draining_timeout_sec = var.connection_draining_timeout_sec
 

--- a/main.tf
+++ b/main.tf
@@ -114,7 +114,7 @@ resource "google_compute_backend_service" "default" {
   protocol                        = var.ssl ? "HTTPS" : "HTTP"
   timeout_sec                     = element(split(",", element(var.backend_params, count.index)), 3)
   # not using element operator since the default behavior is to roll over (mod operation) the index which will return the wrong item from the list if index 6 does not exist
-  security_policy                 = split(",", element(var.backend_params, count.index))[6] != "" ? split(",", element(var.backend_params, count.index))[6] : var.security_policy
+  security_policy                 = length(split(",", element(var.backend_params, count.index))) > 6 && split(",", element(var.backend_params, count.index))[6] != "" ? split(",", element(var.backend_params, count.index))[6] : var.security_policy
   health_checks                   = [element(concat(google_compute_https_health_check.default.*.self_link, google_compute_http_health_check.default.*.self_link), count.index)]
   connection_draining_timeout_sec = var.connection_draining_timeout_sec
 

--- a/main.tf
+++ b/main.tf
@@ -114,7 +114,7 @@ resource "google_compute_backend_service" "default" {
   protocol                        = var.ssl ? "HTTPS" : "HTTP"
   timeout_sec                     = element(split(",", element(var.backend_params, count.index)), 3)
   # not using element operator since the default behavior is to roll over (mod operation) the index which will return the wrong item from the list if index 6 does not exist
-  security_policy                 = split(",", element(var.backend_params, count.index)[6] ? split(",", element(var.backend_params, count.index))[6] : var.security_policy
+  security_policy                 = split(",", element(var.backend_params, count.index))[6] ? split(",", element(var.backend_params, count.index))[6] : var.security_policy
   health_checks                   = [element(concat(google_compute_https_health_check.default.*.self_link, google_compute_http_health_check.default.*.self_link), count.index)]
   connection_draining_timeout_sec = var.connection_draining_timeout_sec
 

--- a/main.tf
+++ b/main.tf
@@ -113,7 +113,8 @@ resource "google_compute_backend_service" "default" {
   port_name                       = element(split(",", element(var.backend_params, count.index)), 1)
   protocol                        = var.ssl ? "HTTPS" : "HTTP"
   timeout_sec                     = element(split(",", element(var.backend_params, count.index)), 3)
-  security_policy                 = var.security_policy
+  # not using element operator since the default behavior is to roll over (mod operation) the index which will return the wrong item from the list if index 6 does not exist
+  security_policy                 = split(",", element(var.backend_params, count.index)[6] ? split(",", element(var.backend_params, count.index))[6] : var.security_policy
   health_checks                   = [element(concat(google_compute_https_health_check.default.*.self_link, google_compute_http_health_check.default.*.self_link), count.index)]
   connection_draining_timeout_sec = var.connection_draining_timeout_sec
 

--- a/main.tf
+++ b/main.tf
@@ -113,8 +113,7 @@ resource "google_compute_backend_service" "default" {
   port_name                       = element(split(",", element(var.backend_params, count.index)), 1)
   protocol                        = var.ssl ? "HTTPS" : "HTTP"
   timeout_sec                     = element(split(",", element(var.backend_params, count.index)), 3)
-  # not using element operator since the default behavior is to roll over (mod operation) the index which will return the wrong item from the list if index 6 does not exist
-  security_policy                 = length(split(",", element(var.backend_params, count.index))) > 6 && split(",", element(var.backend_params, count.index))[6] != "" ? split(",", element(var.backend_params, count.index))[6] : var.security_policy
+  security_policy                 = length(split(",", element(var.backend_params, count.index))) > 6 && element(split(",", element(var.backend_params, count.index)), 6) != "" ? element(split(",", element(var.backend_params, count.index)), 6) : var.security_policy
   health_checks                   = [element(concat(google_compute_https_health_check.default.*.self_link, google_compute_http_health_check.default.*.self_link), count.index)]
   connection_draining_timeout_sec = var.connection_draining_timeout_sec
 


### PR DESCRIPTION
WHAT:

Add an optional 7th param in `backend_params` to allow for individual backend service security policies

WHY:

Need to apply public and private policies to individual api backends as a part of Akamai retirement

see https://gitlab.urbn.com/infrastructure/ecomm-terraform/merge_requests/897