### PR TITLE
Create Cert Map argument in HTTPS Proxy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -54,17 +54,13 @@ resource "google_compute_target_https_proxy" "default" {
   count            = var.ssl ? 1 : 0
   name             = "${var.name}-https-proxy"
   url_map          = element(compact(concat(list(var.url_map), google_compute_url_map.default.*.self_link)), 0)
-  dynamic "ssl_certificates" {
-    for_each           = var.use_ssl_certs ? [1] : []
-    content {
-      ssl_certificates = flatten([google_compute_ssl_certificate.default[count.index].self_link, var.fe_certs == "true" ? ["https://www.googleapis.com/compute/v1/projects/${var.project}/global/sslCertificates/${var.manually_added_san}"] : []])
-    }
+  ssl_certificates {
+    count = var.use_ssl_certs ? 1 : 0
+    ssl_certificates = flatten([google_compute_ssl_certificate.default[count.index].self_link, var.fe_certs == "true" ? ["https://www.googleapis.com/compute/v1/projects/${var.project}/global/sslCertificates/${var.manually_added_san}"] : []])
   }
-  dynamic "certificate_map" {
-    for_each           = var.use_cert_map ? [1] : []
-    content {
-      certificate_map  = var.certificate_map
-    }
+  certificate_map {
+    count = var.use_cert_map ? 1 : 0
+    certificate_map  = var.certificate_map
   }
   quic_override    = "NONE"
 }

--- a/main.tf
+++ b/main.tf
@@ -54,6 +54,7 @@ resource "google_compute_target_https_proxy" "default" {
   count            = var.ssl ? 1 : 0
   name             = "${var.name}-https-proxy"
   url_map          = element(compact(concat(list(var.url_map), google_compute_url_map.default.*.self_link)), 0)
+  certificate_map  = var.certificate_map
   ssl_certificates = flatten([google_compute_ssl_certificate.default[count.index].self_link, var.fe_certs == "true" ? ["https://www.googleapis.com/compute/v1/projects/${var.project}/global/sslCertificates/${var.manually_added_san}"] : []])
   quic_override    = "NONE"
 }

--- a/main.tf
+++ b/main.tf
@@ -54,8 +54,18 @@ resource "google_compute_target_https_proxy" "default" {
   count            = var.ssl ? 1 : 0
   name             = "${var.name}-https-proxy"
   url_map          = element(compact(concat(list(var.url_map), google_compute_url_map.default.*.self_link)), 0)
-  certificate_map  = var.certificate_map
-  ssl_certificates = flatten([google_compute_ssl_certificate.default[count.index].self_link, var.fe_certs == "true" ? ["https://www.googleapis.com/compute/v1/projects/${var.project}/global/sslCertificates/${var.manually_added_san}"] : []])
+  dynamic "ssl_certificates" {
+    for_each           = var.use_ssl_certs ? [1] : []
+    content {
+      ssl_certificates = flatten([google_compute_ssl_certificate.default[count.index].self_link, var.fe_certs == "true" ? ["https://www.googleapis.com/compute/v1/projects/${var.project}/global/sslCertificates/${var.manually_added_san}"] : []])
+    }
+  }
+  dynamic "certificate_map" {
+    for_each           = var.use_cert_map ? [1] : []
+    content {
+      certificate_map  = var.certificate_map
+    }
+  }
   quic_override    = "NONE"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -54,14 +54,8 @@ resource "google_compute_target_https_proxy" "default" {
   count            = var.ssl ? 1 : 0
   name             = "${var.name}-https-proxy"
   url_map          = element(compact(concat(list(var.url_map), google_compute_url_map.default.*.self_link)), 0)
-  ssl_certificates {
-    count = var.use_ssl_certs ? 1 : 0
-    ssl_certificates = flatten([google_compute_ssl_certificate.default[count.index].self_link, var.fe_certs == "true" ? ["https://www.googleapis.com/compute/v1/projects/${var.project}/global/sslCertificates/${var.manually_added_san}"] : []])
-  }
-  certificate_map {
-    count = var.use_cert_map ? 1 : 0
-    certificate_map  = var.certificate_map
-  }
+  certificate_map  = var.certificate_map
+  ssl_certificates = flatten([google_compute_ssl_certificate.default[count.index].self_link, var.fe_certs == "true" ? ["https://www.googleapis.com/compute/v1/projects/${var.project}/global/sslCertificates/${var.manually_added_san}"] : []])
   quic_override    = "NONE"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -94,18 +94,6 @@ variable certificate_map {
   default     = ""
 }
 
-variable use_ssl_certs {
-  description = "Set to true if using SSL certs directly attached to the GLB."
-  type        = bool
-  default     = false
-}
-
-variable use_cert_map {
-  description = "Set to true if using a GCP Cert Map on the target proxy."
-  type        = bool
-  default     = false
-}
-
 variable security_policy {
   description = "Backend service security policy. Will be applied to all backends if supplied."
   default     = ""

--- a/variables.tf
+++ b/variables.tf
@@ -94,6 +94,16 @@ variable certificate_map {
   default     = ""
 }
 
+variable use_ssl_certs {
+  description = "Set to true if using SSL certs directly attached to the GLB."
+  default     = ""
+}
+
+variable use_cert_map {
+  description = "Set to true if using a GCP Cert Map on the target proxy."
+  default     = ""
+}
+
 variable security_policy {
   description = "Backend service security policy. Will be applied to all backends if supplied."
   default     = ""

--- a/variables.tf
+++ b/variables.tf
@@ -89,6 +89,11 @@ variable certificate {
   default     = ""
 }
 
+variable certificate_map {
+  description = "Link to the Certificate Map. Required if ssl is `true`."
+  default     = ""
+}
+
 variable security_policy {
   description = "Backend service security policy. Will be applied to all backends if supplied."
   default     = ""

--- a/variables.tf
+++ b/variables.tf
@@ -96,12 +96,14 @@ variable certificate_map {
 
 variable use_ssl_certs {
   description = "Set to true if using SSL certs directly attached to the GLB."
-  default     = ""
+  type        = bool
+  default     = false
 }
 
 variable use_cert_map {
   description = "Set to true if using a GCP Cert Map on the target proxy."
-  default     = ""
+  type        = bool
+  default     = false
 }
 
 variable security_policy {


### PR DESCRIPTION
**WHAT**

Add `certificate_map` to `target_https_proxy`. 

**WHY**  
For GLB's using this module, this argument is required to enable cert maps. 