### PR TITLE
Add Cert Map to HTTPS Proxy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -46,6 +46,7 @@ resource "google_compute_target_https_proxy" "default" {
 
 resource "google_compute_ssl_certificate" "default" {
   project     = var.project
+  count       = var.ssl ? 1 : 0
   name        = join("-", compact(list(var.name, "certificate", var.cert_version)))
   private_key = var.private_key
   certificate = var.certificate

--- a/main.tf
+++ b/main.tf
@@ -93,7 +93,8 @@ resource "google_compute_backend_service" "default" {
     for_each = var.backends[count.index]
 
     content {
-      group = backend.value["group"]
+      group           = backend.value["group"]
+      max_utilization = lookup(backend.value, "max_utilization", 0.80)
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -106,7 +106,8 @@ resource "google_compute_backend_service" "default" {
     for_each = var.backends[count.index]
 
     content {
-      group = backend.value["group"]
+      group           = backend.value["group"]
+      max_utilization = lookup(backend.value, "max_utilization", 0.80)
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -39,21 +39,8 @@ resource "google_compute_target_https_proxy" "default" {
   count            = var.ssl ? 1 : 0
   name             = "${var.name}-https-proxy"
   url_map          = element(compact(concat(list(var.url_map), google_compute_url_map.default.*.self_link)), 0)
-  ssl_certificates = var.sslcert ? flatten([google_compute_ssl_certificate.default[count.index].self_link, var.fe_certs == "true" ? ["https://www.googleapis.com/compute/v1/projects/${var.project}/global/sslCertificates/${var.manually_added_san}"] : []]) : null
   certificate_map  = var.certmap
   quic_override    = "NONE"
-}
-
-resource "google_compute_ssl_certificate" "default" {
-  project     = var.project
-  count       = var.ssl ? 1 : 0
-  name        = join("-", compact(list(var.name, "certificate", var.cert_version)))
-  private_key = var.private_key
-  certificate = var.certificate
-
-  lifecycle {
-    create_before_destroy = true
-  }
 }
 
 # HTTP(S) Redirect

--- a/main.tf
+++ b/main.tf
@@ -33,19 +33,20 @@ resource "google_compute_global_forwarding_rule" "https" {
   port_range = "443"
 }
 
-# HTTPS proxy  when ssl is true
+# HTTPS proxy when ssl is true
 resource "google_compute_target_https_proxy" "default" {
   project          = var.project
   count            = var.ssl ? 1 : 0
   name             = "${var.name}-https-proxy"
   url_map          = element(compact(concat(list(var.url_map), google_compute_url_map.default.*.self_link)), 0)
-  ssl_certificates = flatten([google_compute_ssl_certificate.default[count.index].self_link, var.fe_certs == "true" ? ["https://www.googleapis.com/compute/v1/projects/${var.project}/global/sslCertificates/${var.manually_added_san}"] : []])
+  ssl_certificates = var.sslcert ? flatten([google_compute_ssl_certificate.default[count.index].self_link, var.fe_certs == "true" ? ["https://www.googleapis.com/compute/v1/projects/${var.project}/global/sslCertificates/${var.manually_added_san}"] : []]) : null
+  certificate_map  = var.certmap
   quic_override    = "NONE"
 }
 
 resource "google_compute_ssl_certificate" "default" {
   project     = var.project
-  count       = var.ssl ? 1 : 0
+  count       = var.sslcert ? 1 : 0
   name        = join("-", compact(list(var.name, "certificate", var.cert_version)))
   private_key = var.private_key
   certificate = var.certificate
@@ -56,7 +57,6 @@ resource "google_compute_ssl_certificate" "default" {
 }
 
 # HTTP(S) Redirect
-
 resource "google_compute_url_map" "https_redirect" {
   project = var.project
   count   = var.https_redirect ? 1 : 0

--- a/main.tf
+++ b/main.tf
@@ -46,7 +46,6 @@ resource "google_compute_target_https_proxy" "default" {
 
 resource "google_compute_ssl_certificate" "default" {
   project     = var.project
-  count       = var.sslcert ? 1 : 0
   name        = join("-", compact(list(var.name, "certificate", var.cert_version)))
   private_key = var.private_key
   certificate = var.certificate

--- a/variables.tf
+++ b/variables.tf
@@ -89,6 +89,16 @@ variable certificate {
   default     = ""
 }
 
+variable certmap {
+  description = "Link to the Certificate Map value at the GLB."
+  default     = null
+}
+
+variable sslcert {
+  description = "Flag for `ssl_certificates`. 'true' uses what's in the module. false sets the argument to null."
+  default     = true
+}
+
 variable security_policy {
   description = "Backend service security policy. Will be applied to all backends if supplied."
   default     = ""

--- a/variables.tf
+++ b/variables.tf
@@ -19,16 +19,6 @@ variable project {
   default     = ""
 }
 
-variable manually_added_san {
-  description = "add if a manually added san cert is on the LB"
-  default     = ""
-}
-
-variable fe_certs {
-  description = "set to true to add a brand_san"
-  default     = "false"
-}
-
 variable region {
   description = "Region for cloud resources"
   default     = "us-central1"
@@ -75,18 +65,8 @@ variable url_map {
 }
 
 variable ssl {
-  description = "Set to `true` to enable SSL support, requires variables `private_key` and `certificate`."
+  description = "Set to `true` to enable SSL support. Requires `certmap` entry."
   default     = false
-}
-
-variable private_key {
-  description = "Content of the private SSL key. Required if ssl is `true`."
-  default     = ""
-}
-
-variable certificate {
-  description = "Content of the SSL certificate. Required if ssl is `true`."
-  default     = ""
 }
 
 variable certmap {
@@ -94,18 +74,8 @@ variable certmap {
   default     = null
 }
 
-variable sslcert {
-  description = "Flag for `ssl_certificates`. 'true' uses what's in the module. false sets the argument to null."
-  default     = true
-}
-
 variable security_policy {
   description = "Backend service security policy. Will be applied to all backends if supplied."
-  default     = ""
-}
-
-variable cert_version {
-  description = "The version of the certificate and key combination. Used to avoid naming conflicts on update."
   default     = ""
 }
 


### PR DESCRIPTION
**WHAT**

Add `certificate_map` to `target_https_proxy`. 

**WHY**  
For GLB's using this module, this argument is required to enable cert maps. 