### PR TITLE
Adding reference to provider-version module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -15,7 +15,7 @@
  */
 
 data "google_compute_global_address" "default" {
-  name     = element(concat(google_compute_global_address.default.*.name, list(var.ip_address_name)), 0)
+  name = element(concat(google_compute_global_address.default.*.name, list(var.ip_address_name)), 0)
 }
 
 resource "google_compute_global_address" "default" {

--- a/main.tf
+++ b/main.tf
@@ -15,7 +15,6 @@
  */
 
 data "google_compute_global_address" "default" {
-  provider = module.provider-version.google
   name     = element(concat(google_compute_global_address.default.*.name, list(var.ip_address_name)), 0)
 }
 

--- a/main.tf
+++ b/main.tf
@@ -15,7 +15,8 @@
  */
 
 data "google_compute_global_address" "default" {
-  name = element(concat(google_compute_global_address.default.*.name, list(var.ip_address_name)), 0)
+  provider = module.provider-version.google
+  name     = element(concat(google_compute_global_address.default.*.name, list(var.ip_address_name)), 0)
 }
 
 resource "google_compute_global_address" "default" {

--- a/provider-version.tf
+++ b/provider-version.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_providers {
+    google = {
+      version = var.google_provider_version
+    }
+    google-beta = {
+      version = var.google_beta_provider_version
+    }
+  }
+}
+
+provider "google" {
+  project = var.project
+  region  = var.region
+  zone    = var.zone
+}
+
+provider "google-beta" {
+  project = var.project
+  region  = var.region
+  zone    = var.zone
+}

--- a/variables.tf
+++ b/variables.tf
@@ -14,6 +14,16 @@
  * limitations under the License.
  */
 
+variable google_provider_version {
+  description = "Google provider-version for TF."
+  default     = "4.84.0"
+}
+
+variable google_beta_provider_version {
+  description = "Google beta provider-version for TF."
+  default     = "4.84.0"
+}
+
 variable project {
   description = "The project to deploy to, if not set the default provider project is used."
   default     = ""


### PR DESCRIPTION
**WHAT**  
Add reference to the newly created Google provider-version module for ecomm-terraform. 

**WHY**  
WIth the provider-version as a module, the "google_compute_global_address" needs to be able to reference the module since it's no longer in the TF for the service. 