### PR TITLE
Set max_utilization with a default value and variable option

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -106,7 +106,8 @@ resource "google_compute_backend_service" "default" {
     for_each = var.backends[count.index]
 
     content {
-      group = backend.value["group"]
+      group           = backend.value["group"]
+      max_utilization = lookup(backend.value, "max_utilization", 0.80)
     }
   }
 }


### PR DESCRIPTION
**WHAT**  
Set max_utilization for the backends to default 0.80 value, and allow for a variable so it can be adjusted downstream. 

**WHY**  
max_utilization not being set is causing issues when upgrading provider versions. 

