### PR TITLE
Remove Compute SSL Configuration

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -93,7 +93,8 @@ resource "google_compute_backend_service" "default" {
     for_each = var.backends[count.index]
 
     content {
-      group = backend.value["group"]
+      group           = backend.value["group"]
+      max_utilization = lookup(backend.value, "max_utilization", 0.80)
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -39,21 +39,8 @@ resource "google_compute_target_https_proxy" "default" {
   count            = var.ssl ? 1 : 0
   name             = "${var.name}-https-proxy"
   url_map          = element(compact(concat(list(var.url_map), google_compute_url_map.default.*.self_link)), 0)
-  ssl_certificates = var.sslcert ? flatten([google_compute_ssl_certificate.default[count.index].self_link, var.fe_certs == "true" ? ["https://www.googleapis.com/compute/v1/projects/${var.project}/global/sslCertificates/${var.manually_added_san}"] : []]) : null
   certificate_map  = var.certmap
   quic_override    = "NONE"
-}
-
-resource "google_compute_ssl_certificate" "default" {
-  project     = var.project
-  count       = var.ssl ? 1 : 0
-  name        = join("-", compact(list(var.name, "certificate", var.cert_version)))
-  private_key = var.private_key
-  certificate = var.certificate
-
-  lifecycle {
-    create_before_destroy = true
-  }
 }
 
 # HTTP(S) Redirect

--- a/variables.tf
+++ b/variables.tf
@@ -19,16 +19,6 @@ variable project {
   default     = ""
 }
 
-variable manually_added_san {
-  description = "add if a manually added san cert is on the LB"
-  default     = ""
-}
-
-variable fe_certs {
-  description = "set to true to add a brand_san"
-  default     = "false"
-}
-
 variable region {
   description = "Region for cloud resources"
   default     = "us-central1"
@@ -75,18 +65,8 @@ variable url_map {
 }
 
 variable ssl {
-  description = "Set to `true` to enable SSL support, requires variables `private_key` and `certificate`."
+  description = "Set to `true` to enable SSL support. Requires `certmap` entry."
   default     = false
-}
-
-variable private_key {
-  description = "Content of the private SSL key. Required if ssl is `true`."
-  default     = ""
-}
-
-variable certificate {
-  description = "Content of the SSL certificate. Required if ssl is `true`."
-  default     = ""
 }
 
 variable certmap {
@@ -94,18 +74,8 @@ variable certmap {
   default     = null
 }
 
-variable sslcert {
-  description = "Flag for `ssl_certificates`. 'true' uses what's in the module. false sets the argument to null."
-  default     = true
-}
-
 variable security_policy {
   description = "Backend service security policy. Will be applied to all backends if supplied."
-  default     = ""
-}
-
-variable cert_version {
-  description = "The version of the certificate and key combination. Used to avoid naming conflicts on update."
   default     = ""
 }
 


### PR DESCRIPTION
**WHAT**  
Remove the existing Compute SSL configuration that directly attaches SSL certs to the GLB. 

**WHY**  
We've migrated to Certificate Manager, where the SSL certs are managed centrally per environment, add to a certificate map, and then attached to the HTTPS proxy. 

This means the old directly-attached SSL cert configuration is no longer needed. 
 